### PR TITLE
HDFS权限修复

### DIFF
--- a/src/main/java/com/briup/big/DoBIg.java
+++ b/src/main/java/com/briup/big/DoBIg.java
@@ -28,6 +28,7 @@ public class DoBIg {
 			String sqlTruncate = "truncate table grms";
 			Da.exist(sqlTruncate);
 
+			System.setProperty("HADOOP_USER_NAME","mynn");
 			Configuration conf  = new Configuration();
 			conf.set("fs.defaultFS", "hdfs://mynn:9000");
 			FileSystem fs = FileSystem.get(conf);

--- a/src/main/java/com/briup/big/UpDataHdfs.java
+++ b/src/main/java/com/briup/big/UpDataHdfs.java
@@ -13,6 +13,7 @@ import org.apache.hadoop.fs.Path;
 public class UpDataHdfs {
 	public static void update(){
 		try {
+			System.setProperty("HADOOP_USER_NAME","mynn");
 			Configuration conf  = new Configuration();
 			conf.set("fs.defaultFS", "hdfs://mynn:9000");
 			FileSystem fs = FileSystem.get(conf);
@@ -41,6 +42,7 @@ public class UpDataHdfs {
 	 * */
 	public static void ttt(){
 		try {
+			System.setProperty("HADOOP_USER_NAME","mynn");
 			Configuration conf  = new Configuration();
 			conf.set("fs.defaultFS", "hdfs://mynn:9000");
 			FileSystem fs = FileSystem.get(conf);
@@ -58,6 +60,7 @@ public class UpDataHdfs {
 	public static void nnn(int i ){
 		try {
 
+			System.setProperty("HADOOP_USER_NAME","mynn");
 			Configuration conf  = new Configuration();
 			conf.set("fs.defaultFS", "hdfs://aaa:9000");
 			FileSystem fs = FileSystem.get(conf);

--- a/src/main/java/com/briup/big/main/M1.java
+++ b/src/main/java/com/briup/big/main/M1.java
@@ -23,6 +23,7 @@ public class M1 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		FileSystem fs = FileSystem.get(conf);

--- a/src/main/java/com/briup/big/main/M2.java
+++ b/src/main/java/com/briup/big/main/M2.java
@@ -24,6 +24,7 @@ public class M2 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		FileSystem fs = FileSystem.get(conf);

--- a/src/main/java/com/briup/big/main/M3.java
+++ b/src/main/java/com/briup/big/main/M3.java
@@ -22,6 +22,7 @@ public class M3 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		

--- a/src/main/java/com/briup/big/main/M4.java
+++ b/src/main/java/com/briup/big/main/M4.java
@@ -21,6 +21,7 @@ public class M4 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		

--- a/src/main/java/com/briup/big/main/M5.java
+++ b/src/main/java/com/briup/big/main/M5.java
@@ -23,6 +23,7 @@ public class M5 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		

--- a/src/main/java/com/briup/big/main/M6.java
+++ b/src/main/java/com/briup/big/main/M6.java
@@ -21,6 +21,7 @@ public class M6 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		

--- a/src/main/java/com/briup/big/main/M7.java
+++ b/src/main/java/com/briup/big/main/M7.java
@@ -23,6 +23,7 @@ public class M7 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		

--- a/src/main/java/com/briup/big/main/M8.java
+++ b/src/main/java/com/briup/big/main/M8.java
@@ -24,6 +24,7 @@ public class M8 extends Configured implements Tool {
 
 	@Override
 	public int run(String[] args) throws Exception {
+		System.setProperty("HADOOP_USER_NAME","mynn");
 		Configuration conf  = new Configuration();
 		conf.set("fs.defaultFS", "hdfs://mynn:9000");
 		

--- a/src/main/java/com/briup/big/main/Mall.java
+++ b/src/main/java/com/briup/big/main/Mall.java
@@ -17,6 +17,7 @@ public class Mall {
 	public static void bigin() {
 		try {
 
+			System.setProperty("HADOOP_USER_NAME","mynn");
 			Configuration conf  = new Configuration();
 			conf.set("fs.defaultFS", "hdfs://mynn:9000");
 			FileSystem fs = FileSystem.get(conf);


### PR DESCRIPTION
修复了可能在主机连接虚拟机HDFS产生的权限问题
注：直接使用mynn需要在本机host下新建相应IP的域名